### PR TITLE
allow custom config to hgf_file

### DIFF
--- a/src/huggingface/HuggingFace.jl
+++ b/src/huggingface/HuggingFace.jl
@@ -6,6 +6,7 @@ using HuggingFaceApi
 
 export @hgf_str,
     load_config,
+    load_config_dict,
     load_model,
     load_model!,
     load_tokenizer,

--- a/src/huggingface/configs/auto.jl
+++ b/src/huggingface/configs/auto.jl
@@ -4,8 +4,10 @@
 Get the configuration file of given model.
 """
 load_config(model; kw...) = _load_config(load_config_dict(model; kw...))
+load_config(model, config; kw...) = _load_config(load_config_dict(model, config; kw...))
 
 load_config_dict(model_name; kw...) = json_load(hgf_model_config(model_name; kw...))
+load_config_dict(model_name, config; kw...) = json_load(hgf_model_config(model_name, config; kw...))
 
 _load_config(cfg_file::AbstractString) = _load_config(json_load(cfg_file))
 function _load_config(cfg)

--- a/src/huggingface/download.jl
+++ b/src/huggingface/download.jl
@@ -39,7 +39,9 @@ end
 
 hgf_file(model_name, file_name; revision = "main", kws...) = _hgf_download(hgf_file_url(model_name, file_name; revision); kws...)
 
+hgf_model_config(model_name, config; kws...) = hgf_file(model_name, config; kws...)
 hgf_model_config(model_name; kws...) = hgf_file(model_name, CONFIG_NAME; kws...)
+hgf_model_weight(model_name, config; kws...) = hgf_file(model_name, config; kws...)
 hgf_model_weight(model_name; kws...) = hgf_file(model_name, PYTORCH_WEIGHTS_NAME; kws...)
 hgf_vocab(model_name; kws...) = hgf_file(model_name, VOCAB_FILE; kws...)
 hgf_vocab_json(model_name; kws...) = hgf_file(model_name, VOCAB_JSON_FILE; kws...)

--- a/src/huggingface/weight.jl
+++ b/src/huggingface/weight.jl
@@ -12,6 +12,12 @@ function load_state(model_name; kw...)
   return state
 end
 
+function load_state(model_name, config; kw...)
+  state_dict = load_state_dict(model_name, config; kw...)
+  state = state_dict_to_namedtuple(state_dict)
+  return state
+end
+
 """
   `load_state_dict(model_name)`
 
@@ -21,6 +27,11 @@ See also: [`state_dict_to_namedtuple`](@ref)
 """
 function load_state_dict(model_name; kw...)
   state_dict = Pickle.Torch.THload(hgf_model_weight(model_name; kw...))
+  return state_dict
+end
+
+function load_state_dict(model_name, config; kw...)
+  state_dict = Pickle.Torch.THload(hgf_model_weight(model_name, config; kw...))
   return state_dict
 end
 


### PR DESCRIPTION
- modify load_config, load_state_dict for custom configs
- HuggingFace diffusion models have bin & cfg file names in a different format than transformers.